### PR TITLE
Remove deprecated #setup method, which is deprecated in Rails 4.1.

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -25,7 +25,7 @@ module ValidatesTimeliness
 
     # Prior to version 4.1, Rails will call `#setup`, if defined. This method is deprecated in Rails 4.1 and removed
     # altogether in 4.2.
-    SETUP_DEPRECATED = ActiveRecord.respond_to?(:version) && ActiveRecord.version >= Gem::Version.new('4.1')
+    SETUP_DEPRECATED = ActiveModel.respond_to?(:version) && ActiveModel.version >= Gem::Version.new('4.1')
 
     def self.kind
       :timeliness


### PR DESCRIPTION
Defining `#setup` on Validators is deprecated in Rails 4.1 and is planned to be removed altogether in Rails 4.2. In the meantime, defining `setup` causes deprecation warnings.

This patch is cribbed from a couple of suggested solutions discussed in issue #114 and suppresses deprecation warnings in Rails 4.1 and will work in Rails 4.2, as well as older versions.

I haven't included any tests because I couldn't figure out how to cleanly mimic the different behaviours of different Rails versions.
