### PR TITLE
InstanceTag was renamed to ActiveModelInstanceTag

### DIFF
--- a/lib/validates_timeliness/extensions.rb
+++ b/lib/validates_timeliness/extensions.rb
@@ -5,7 +5,7 @@ module ValidatesTimeliness
   end
 
   def self.enable_date_time_select_extension!
-    ::ActionView::Helpers::InstanceTag.send(:include, ValidatesTimeliness::Extensions::DateTimeSelect)
+    ::ActionView::Helpers::ActiveModelInstanceTag.send(:include, ValidatesTimeliness::Extensions::DateTimeSelect)
   end
 
   def self.enable_multiparameter_extension!


### PR DESCRIPTION
ActionView::Helpers::InstanceTag was renamed to ActionView::Helpers::ActiveModelInstanceTag

It was renamed in v3.0.9