### PR TITLE
Use value_before_type_cast method of Attribute object for Rails 4.2

### DIFF
--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -46,7 +46,7 @@ module ValidatesTimeliness
             @timeliness_cache ||= {}
             @timeliness_cache["#{attr_name}"] = original_value
             #{ "if value.is_a?(String)\n#{timeliness_type_cast_code(attr_name, 'value')}\nend" if ValidatesTimeliness.use_plugin_parser }
-            
+
             super(value)
           end
         EOV
@@ -56,7 +56,10 @@ module ValidatesTimeliness
       def define_timeliness_before_type_cast_method(attr_name)
         method_body, line = <<-EOV, __LINE__ + 1
           def #{attr_name}_before_type_cast
-            _timeliness_raw_value_for('#{attr_name}') || @attributes['#{attr_name}']
+            _timeliness_raw_value_for('#{attr_name}') || begin
+              a = @attributes['#{attr_name}']
+              a.respond_to?(:value_before_type_cast) ? a.value_before_type_cast : a
+            end
           end
         EOV
         generated_timeliness_methods.module_eval(method_body, __FILE__, line)

--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -56,6 +56,7 @@ module ValidatesTimeliness
       def define_timeliness_before_type_cast_method(attr_name)
         method_body, line = <<-EOV, __LINE__ + 1
           def #{attr_name}_before_type_cast
+            _timeliness_raw_value_for('#{attr_name}') || @attributes['#{attr_name}']
             _timeliness_raw_value_for('#{attr_name}') || begin
               a = @attributes['#{attr_name}']
               a.respond_to?(:value_before_type_cast) ? a.value_before_type_cast : a

--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -56,7 +56,6 @@ module ValidatesTimeliness
       def define_timeliness_before_type_cast_method(attr_name)
         method_body, line = <<-EOV, __LINE__ + 1
           def #{attr_name}_before_type_cast
-            _timeliness_raw_value_for('#{attr_name}') || @attributes['#{attr_name}']
             _timeliness_raw_value_for('#{attr_name}') || begin
               a = @attributes['#{attr_name}']
               a.respond_to?(:value_before_type_cast) ? a.value_before_type_cast : a

--- a/lib/validates_timeliness/conversion.rb
+++ b/lib/validates_timeliness/conversion.rb
@@ -60,7 +60,7 @@ module ValidatesTimeliness
       if ValidatesTimeliness.use_plugin_parser
         Timeliness::Parser.parse(value, @type, :zone => (:current if @timezone_aware), :format => options[:format], :strict => false)
       else
-        @timezone_aware ? Time.zone.parse(value) : value.to_time(ValidatesTimeliness.default_timezone)
+        @timezone_aware ? Time.zone.parse(value, Time.zone.now) : value.to_time(ValidatesTimeliness.default_timezone)
       end
     rescue ArgumentError, TypeError
       nil

--- a/spec/validates_timeliness/conversion_spec.rb
+++ b/spec/validates_timeliness/conversion_spec.rb
@@ -69,7 +69,7 @@ describe ValidatesTimeliness::Conversion do
         value = Time.utc(2010, 1, 1, 12, 34, 56)
         result = type_cast_value(value, :datetime)
         expect(result).to eq(Time.zone.local(2010, 1, 1, 23, 34, 56))
-        expect(result.zone).to eq('EST')
+        expect(result.zone).to eq('AEDT') # 'Australia/Melbourne'
       end
 
       it 'should return nil for invalid value types' do
@@ -90,7 +90,7 @@ describe ValidatesTimeliness::Conversion do
         value = Time.utc(2010, 1, 1, 12, 34, 56, 10000)
         result = type_cast_value(value, :datetime)
         expect(result).to eq(Time.zone.local(2010, 1, 1, 23, 34, 56))
-        expect(result.zone).to eq('EST')
+        expect(result.zone).to eq('AEDT') # 'Australia/Melbourne'
       end
     end
   end

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -163,6 +163,7 @@ describe ValidatesTimeliness, 'ActiveRecord' do
       end
 
       context "for a datetime column" do
+        with_config(:default_timezone, 'Australia/Melbourne')
 
         it 'should parse a string value' do
           expect(Timeliness::Parser).to receive(:parse)

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -163,7 +163,6 @@ describe ValidatesTimeliness, 'ActiveRecord' do
       end
 
       context "for a datetime column" do
-        with_config(:default_timezone, 'Australia/Melbourne')
 
         it 'should parse a string value' do
           expect(Timeliness::Parser).to receive(:parse)


### PR DESCRIPTION
@attributes is now a hash with values being objects of type ActiveRecord::Attribute::FromDatabase. Need to call value_before_type_cast on this object to get the raw value now.