### PR TITLE
Generate attribute methods once instead of on each object creation

### DIFF
--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -71,7 +71,11 @@ module ValidatesTimeliness
       end
 
       def generated_timeliness_methods
-        @generated_timeliness_methods ||= Module.new.tap { |m| include(m) }
+        @generated_timeliness_methods ||= begin
+          mod = const_set(:GeneratedValidatesTimelinessMethods, Module.new)
+          include mod
+          mod
+        end
       end
 
       def undefine_timeliness_attribute_methods

--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -23,7 +23,9 @@ module ValidatesTimeliness
 
         def define_attribute_methods
           super.tap do |attribute_methods_generated|
+            return false if @timeliness_methods_generated
             define_timeliness_methods true
+            @timeliness_methods_generated = true
           end
         end
 


### PR DESCRIPTION
I was investigating memory usage in my app and I found that jc-validates_timeliness created a lot of strings on each request.

It turns out that the attribute methods for timeliness are generated at each object creation instead of once, at first creation like AR attribute methods. Since creating those methods uses `module_eval` it's quite slow when it's done each `Model.new`!

This PR prevents the duplication by following [the same pattern as ActiveRecord](https://github.com/rails/rails/blob/08576b94ad4f19dfc368619d7751e211d23dcad8/activerecord/lib/active_record/attribute_methods.rb#L79).

Benchmark for speed improvement:

```
# rails console
require 'benchmark/ips'
Benchmark.ips do |x|
  x.report("timeliness generated attributes speed") {
    Rental.new # a class in my app that has 3 timeliness validations
  }
end
```

Without patch

```
Calculating -------------------------------------
timeliness generated attributes speed
                       264.000  i/100ms
-------------------------------------------------
timeliness generated attributes speed
                          2.777k (± 5.1%) i/s -     13.992k
```

With patch

```
Calculating -------------------------------------
timeliness generated attributes speed
                       988.000  i/100ms
-------------------------------------------------
timeliness generated attributes speed
                         12.068k (± 4.6%) i/s -     60.268k
```

That's a 4X speed improvement in creating AR objects in my application.

Additionally it names the module to make it easier to see in the ancestor chain.

```
Rental.ancestors
=> [Rental(id: integer, ...),
 Rental::GeneratedValidatesTimelinessMethods, <== instead of #<Module:0x007fc165522078>
 PaperTrail::Model::InstanceMethods,
...
```
