### PR TITLE
WIP on Rails 5.0 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ cache: bundler
 services: mongodb
 
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.3.7
 
 script: 'bundle exec rake'
 

--- a/Appraisals
+++ b/Appraisals
@@ -10,6 +10,14 @@ appraise "rails_3_2" do
   gem "rails", "~> 3.2.0"
 end
 
+appraise "rails_4_2" do
+  gem "rails", "~> 4.2.11"
+end
+
+appraise "rails_5_0" do
+  gem "rails", "~> 5.0.7"
+end
+
 appraise "mongoid_2_1" do
   gem "mongoid", "~> 2.1.0"
 end

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,9 @@
+= master [unreleased]
+* Gem now requires Ruby v2.3+ for Rails 5.0 compat
+
+= 3.1.0 [2014-07-16]
+* Rails 4.2 compat
+
 = 3.0.14 [2012-08-23]
 * Fix for using validates :timeliness => {} form to correctly add attributes to timeliness validated attributes.
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'rails', '~> 3.2.6'
+gem 'rails', '~> 5.0.7'
 gem 'timecop'
 gem 'ruby-debug', :platforms => [:ruby_18, :jruby]
 gem 'debugger', :platforms => [:ruby_19]
@@ -11,7 +11,7 @@ gem 'sqlite3'
 gem 'nokogiri'
 
 group :mongoid do
-  gem 'mongoid', '~> 2.3.0'
+  gem 'mongoid', '~> 6.1.1'
   gem 'bson_ext'
   gem 'system_timer', :platforms => [:ruby_18]
 end

--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@
 
 ## Description
 
-Complete validation of dates, times and datetimes for Rails 3.x and
+Complete validation of dates, times and datetimes for Rails 3+ and
 ActiveModel.
 
-This is a Rails 4.2-compatible fork of
+This is a Rails 4.2+ compatible fork of
 [ jc-validates_timeliness gem] by [johncarney].
 which is a fork of the
 [original validates_timeliness gem][original] by [Adam Meehan][adzap].
 
+## Versions
+- v3.x for Rails3
+- v4.x for Rails4
+- v5.x for Rails5 (requires Ruby v2.2+)
 
 ## Features
 
@@ -29,7 +33,7 @@ which is a fork of the
 ## Installation
 
     # in Gemfile
-    gem 'jc-validates_timeliness'
+    gem 'jc-validates_timeliness', '~> 3.1'
 
     # Run bundler
     $ bundle install
@@ -46,23 +50,25 @@ NOTE: You may wish to enable the plugin parser and the extensions to start.
 
 ## Examples
 
-    validates_datetime :occurred_at
+```
+validates_datetime :occurred_at
 
-    validates_date :date_of_birth, :before => lambda { 18.years.ago },
-                                   :before_message => "must be at least 18 years old"
+validates_date :date_of_birth, :before => lambda { 18.years.ago },
+                               :before_message => "must be at least 18 years old"
 
-    validates_datetime :finish_time, :after => :start_time # Method symbol
+validates_datetime :finish_time, :after => :start_time # Method symbol
 
-    validates_date :booked_at, :on => :create, :on_or_after => :today # See Restriction Shorthand.
+validates_date :booked_at, :on => :create, :on_or_after => :today # See Restriction Shorthand.
 
-    validates_time :booked_at, :between => ['9:00am', '5:00pm'] # On or after 9:00AM and on or before 5:00PM
-    validates_time :booked_at, :between => '9:00am'..'5:00pm' # The same as previous example
-    validates_time :booked_at, :between => '9:00am'...'5:00pm' # On or after 9:00AM and strictly before 5:00PM
+validates_time :booked_at, :between => ['9:00am', '5:00pm'] # On or after 9:00AM and on or before 5:00PM
+validates_time :booked_at, :between => '9:00am'..'5:00pm' # The same as previous example
+validates_time :booked_at, :between => '9:00am'...'5:00pm' # On or after 9:00AM and strictly before 5:00PM
 
-    validates_time :breakfast_time, :on_or_after => '6:00am',
-                                    :on_or_after_message => 'must be after opening time',
-                                    :before => :lunchtime,
-                                    :before_message => 'must be before lunch time'
+validates_time :breakfast_time, :on_or_after => '6:00am',
+                                :on_or_after_message => 'must be after opening time',
+                                :before => :lunchtime,
+                                :before_message => 'must be before lunch time'
+```
 
 ## Usage
 
@@ -294,6 +300,13 @@ To activate it, uncomment this line in the initializer:
 
     # in the setup block
     config.enable_date_time_select_extension!
+
+## Developing the gem further
+1. Fork and clone the repo
+2. Bundle
+3. Run `rspec` to see if all tests pass
+4. TDD the new feature
+5. Make a PR
 
 ## Contributors
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'rspec'
 require 'rspec/collection_matchers'
 

--- a/validates_timeliness.gemspec
+++ b/validates_timeliness.gemspec
@@ -18,8 +18,11 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<timeliness>, ["~> 0.3.7"])
 
+  s.required_ruby_version = ">= 2.3.7"
+
   s.add_development_dependency "coveralls"
-  s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "rspec-rails", "~> 3.0"
+  s.add_development_dependency "pry"
+  s.add_development_dependency "rspec", ">= 3.8"
+  s.add_development_dependency "rspec-rails", "~> 3.8"
   s.add_development_dependency "rspec-collection_matchers"
 end


### PR DESCRIPTION
Hello, John,

Here I've started to make the gem compatible with Rails v5.0, the main idea is to bump Ruby version and refactor `alias_method_chain` to `Module#prepend` use.

Unfortunately, I ran into a weird problem - running `rspec` errs out:

```
NameError:
  uninitialized constant ActionView::Helpers::InstanceTag
# ./lib/validates_timeliness/extensions.rb:9:in `enable_date_time_select_extension!'
```

The thing is, when I check out my Rails 5.0-using app the constant is defined, so not sure what is going on. I also tried `require 'rails'` to see if maybe require namespace has changed, but no, still undefined.

Maybe you have an idea how I could proceed.